### PR TITLE
log experiment source as LabML

### DIFF
--- a/client/labml/internal/tracker/writers/comet.py
+++ b/client/labml/internal/tracker/writers/comet.py
@@ -37,6 +37,7 @@ class Writer(WriteBase):
 
     def init(self, name: str):
         self.run = self.comet.Experiment(project_name=name)
+        self.run.log_other('Created from', 'LabML')
 
     @staticmethod
     def _parse_key(key: str):


### PR DESCRIPTION
This PR:

Adds logging to track the source of the created Comet experiment as "LabML"